### PR TITLE
fix: resolved bugs given by QA

### DIFF
--- a/lib/app/ui/pages/authentication/sign_up_screen.dart
+++ b/lib/app/ui/pages/authentication/sign_up_screen.dart
@@ -112,7 +112,7 @@ class SignUpScreen extends GetItHook<AuthController> {
                 child: CustomImageView(
                   height: 17.h,
                   imagePath: controller.selectedImage.value == null
-                      ? AssetConstants.icCamera
+                      ? AssetConstants.icEdit
                       : AssetConstants.icEdit,
                 ),
               ),

--- a/lib/app/ui/pages/setting/contact_us_screen.dart
+++ b/lib/app/ui/pages/setting/contact_us_screen.dart
@@ -80,6 +80,11 @@ class ContactUsScreen extends GetItHook<SettingController> {
         margin: const EdgeInsets.all(16),
         height: 28.h,
       ),
+      style: Get.textTheme.bodyMedium?.copyWith(
+        fontWeight: FontWeight.w500,
+        fontSize: 18,
+        color: Get.theme.customColors.grey,
+      ),
       controller: controller.cantactUsEmailController,
       hintLabel: AppStrings.T.email,
       validator: AppValidations.emailValidation,

--- a/lib/app/ui/pages/setting/edit_profile_screen.dart
+++ b/lib/app/ui/pages/setting/edit_profile_screen.dart
@@ -85,7 +85,7 @@ class EditProfileScreen extends GetItHook<SettingController> {
                 child: CustomImageView(
                   height: 17.h,
                   imagePath: controller.tempSelectedImage.value == null
-                      ? AssetConstants.icCamera
+                      ? AssetConstants.icEdit
                       : AssetConstants.icEdit,
                 ),
               ),
@@ -257,6 +257,11 @@ class EditProfileScreen extends GetItHook<SettingController> {
         imagePath: AssetConstants.icEmail,
         margin: const EdgeInsets.all(16),
         height: 28.h,
+      ),
+      style: Get.textTheme.bodyMedium?.copyWith(
+        fontWeight: FontWeight.w500,
+        fontSize: 18,
+        color: Get.theme.customColors.grey,
       ),
       controller: controller.editProfileEmailController,
       hintLabel: AppStrings.T.email,

--- a/lib/app/ui/pages/setting/my_profile_screen.dart
+++ b/lib/app/ui/pages/setting/my_profile_screen.dart
@@ -79,7 +79,7 @@ class MyProfileScreen extends GetItHook<SettingController> {
 
   Widget _buildNameField() {
     return TextInputField(
-      type: InputType.email,
+      type: InputType.name,
       readOnly: true,
       prefixIcon: CustomImageView(
         imagePath: AssetConstants.icProfile,
@@ -88,6 +88,11 @@ class MyProfileScreen extends GetItHook<SettingController> {
       ),
       controller: controller.editProfileNameController,
       hintLabel: AppStrings.T.nameLabel,
+      style: Get.textTheme.bodyMedium?.copyWith(
+        fontWeight: FontWeight.w500,
+        fontSize: 18,
+        color: Get.theme.customColors.grey,
+      ),
     );
   }
 
@@ -100,6 +105,11 @@ class MyProfileScreen extends GetItHook<SettingController> {
         imagePath: AssetConstants.icEmail,
         margin: const EdgeInsets.all(16),
         height: 28.h,
+      ),
+      style: Get.textTheme.bodyMedium?.copyWith(
+        fontWeight: FontWeight.w500,
+        fontSize: 18,
+        color: Get.theme.customColors.grey,
       ),
       controller: controller.editProfileEmailController,
       hintLabel: AppStrings.T.email,

--- a/lib/app/ui/widgets/custom_textfields.dart
+++ b/lib/app/ui/widgets/custom_textfields.dart
@@ -47,7 +47,8 @@ class TextInputField extends TextFormField {
       double? borderRadius,
       super.onTap,
       Function(String)? super.onFieldSubmitted,
-      super.focusNode})
+      super.focusNode,
+      TextStyle? style})
       : assert(
             type != InputType.multiline ||
                 textInputAction == TextInputAction.newline,
@@ -95,11 +96,12 @@ class TextInputField extends TextFormField {
           ],
           obscureText: obscureText?.value ?? false,
           textAlignVertical: TextAlignVertical.top,
-          style: Get.textTheme.bodyMedium?.copyWith(
-            fontWeight: FontWeight.w500,
-            fontSize: 18,
-            color: Get.theme.customColors.white,
-          ),
+          style: style ??
+              Get.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w500,
+                fontSize: 18,
+                color: Get.theme.customColors.white,
+              ),
           decoration: InputDecoration(
             hintStyle: hintStyle ??
                 Get.theme.textTheme.bodyMedium?.copyWith(


### PR DESCRIPTION
-Edit profile >> By default set profile display.
-The color for uneditable text throughout the app should be set to grey, while the color for entered text should align with the specifications outlined in the Figma design.